### PR TITLE
Add configurable options page

### DIFF
--- a/options.css
+++ b/options.css
@@ -1,0 +1,303 @@
+:root {
+  color-scheme: light dark;
+  --bg: #0f172a;
+  --card: rgba(15, 23, 42, 0.55);
+  --border: rgba(148, 163, 184, 0.25);
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --accent: #38bdf8;
+  --success: #34d399;
+  --danger: #f87171;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #f8fafc;
+    --card: #ffffff;
+    --border: #e2e8f0;
+    --text: #0f172a;
+    --muted: #64748b;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.15), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(129, 140, 248, 0.18), transparent 60%),
+    var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  padding: 32px 16px 64px;
+}
+
+.options-container {
+  max-width: 860px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.options-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px;
+  border-radius: 18px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  box-shadow: 0 12px 45px rgba(15, 23, 42, 0.28);
+  backdrop-filter: blur(14px);
+}
+
+.options-title {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+.logo {
+  font-size: 28px;
+  display: grid;
+  place-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.25), rgba(129, 140, 248, 0.35));
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+}
+
+.options-header h1 {
+  margin: 0;
+  font-size: 24px;
+}
+
+.subtitle {
+  margin: 4px 0 0;
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.version {
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.options-card {
+  padding: 24px;
+  background: var(--card);
+  border-radius: 18px;
+  border: 1px solid var(--border);
+  box-shadow: 0 12px 35px rgba(15, 23, 42, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.options-card h2 {
+  margin: 0 0 6px;
+  font-size: 18px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.field label {
+  font-weight: 600;
+}
+
+.field input,
+.field select {
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  font-size: 15px;
+  background: rgba(15, 23, 42, 0.35);
+  color: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+@media (prefers-color-scheme: light) {
+  .field input,
+  .field select {
+    background: rgba(248, 250, 252, 0.9);
+  }
+}
+
+.field input:focus,
+.field select:focus,
+.field input:hover,
+.field select:hover {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.65);
+  box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.12);
+}
+
+.help {
+  margin: 0;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.toggle label:first-child {
+  font-weight: 600;
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 46px;
+  height: 26px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(148, 163, 184, 0.45);
+  transition: 0.2s ease;
+  border-radius: 32px;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 20px;
+  width: 20px;
+  left: 3px;
+  bottom: 3px;
+  background: #fff;
+  transition: 0.2s ease;
+  border-radius: 50%;
+  box-shadow: 0 3px 8px rgba(15, 23, 42, 0.35);
+}
+
+.switch input:checked + .slider {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.7), rgba(129, 140, 248, 0.85));
+}
+
+.switch input:checked + .slider:before {
+  transform: translateX(20px);
+}
+
+.range-field {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.range-field input[type="range"] {
+  flex: 1;
+}
+
+.range-value {
+  font-size: 14px;
+  color: var(--muted);
+  min-width: 120px;
+}
+
+.options-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px;
+  background: var(--card);
+  border-radius: 18px;
+  border: 1px solid var(--border);
+  box-shadow: 0 12px 35px rgba(15, 23, 42, 0.18);
+}
+
+.buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.btn {
+  border: none;
+  border-radius: 12px;
+  padding: 12px 20px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.btn.primary {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.85), rgba(129, 140, 248, 0.95));
+  color: #fff;
+  box-shadow: 0 14px 28px rgba(56, 189, 248, 0.35);
+}
+
+.btn.secondary {
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--text);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.25);
+}
+
+.status {
+  min-height: 20px;
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.status.success {
+  color: var(--success);
+}
+
+.status.error {
+  color: var(--danger);
+}
+
+.hidden {
+  display: none;
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 24px 12px;
+  }
+
+  .options-header,
+  .options-card,
+  .options-actions {
+    padding: 20px;
+  }
+
+  .buttons {
+    flex-direction: column-reverse;
+  }
+
+  .btn {
+    width: 100%;
+  }
+}

--- a/options.html
+++ b/options.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>InstaFile Preferences</title>
+  <link rel="stylesheet" href="options.css">
+</head>
+<body>
+  <main class="options-container">
+    <header class="options-header">
+      <div class="options-title">
+        <span class="logo">⚡</span>
+        <div>
+          <h1>InstaFile Preferences</h1>
+          <p class="subtitle">Customize how Instant saves behave everywhere.</p>
+        </div>
+      </div>
+      <div class="version" id="extension-version"></div>
+    </header>
+
+    <form id="options-form">
+      <section class="options-card">
+        <h2>Storage</h2>
+        <div class="field">
+          <label for="folderPath">Default folder</label>
+          <input id="folderPath" name="folderPath" type="text" placeholder="InstantFiles/">
+          <p class="help">Relative to your default Downloads directory.</p>
+        </div>
+        <div class="field">
+          <label for="namingPattern">Naming pattern</label>
+          <select id="namingPattern" name="namingPattern">
+            <option value="timestamp">Timestamp &mdash; <code>instant_YYYY-MM-DD</code></option>
+            <option value="firstline">First line of selection</option>
+            <option value="custom">Custom template</option>
+          </select>
+        </div>
+        <div class="field hidden" id="custom-pattern-row">
+          <label for="customPattern">Custom filename template</label>
+          <input id="customPattern" name="customPattern" type="text" placeholder="file_{date}_{type}">
+          <p class="help">Available tokens: <code>{date}</code>, <code>{time}</code>, <code>{type}</code></p>
+        </div>
+        <div class="toggle">
+          <label for="organizeByType">Organize by format</label>
+          <label class="switch">
+            <input id="organizeByType" name="organizeByType" type="checkbox">
+            <span class="slider"></span>
+          </label>
+        </div>
+      </section>
+
+      <section class="options-card">
+        <h2>Capture intelligence</h2>
+        <div class="toggle">
+          <label for="autoDetectType">Smart format detection</label>
+          <label class="switch">
+            <input id="autoDetectType" name="autoDetectType" type="checkbox">
+            <span class="slider"></span>
+          </label>
+        </div>
+        <div class="toggle">
+          <label for="enableSmartDetection">Highlight detected type in page</label>
+          <label class="switch">
+            <input id="enableSmartDetection" name="enableSmartDetection" type="checkbox">
+            <span class="slider"></span>
+          </label>
+        </div>
+        <div class="field">
+          <label for="selectionThreshold">Minimum selection length</label>
+          <div class="range-field">
+            <input id="selectionThreshold" name="selectionThreshold" type="range" min="0" max="200" step="5">
+            <span class="range-value"><span id="selectionThresholdValue">0</span> characters</span>
+          </div>
+        </div>
+      </section>
+
+      <section class="options-card">
+        <h2>Interface</h2>
+        <div class="toggle">
+          <label for="showFloatingButton">Floating quick-save button</label>
+          <label class="switch">
+            <input id="showFloatingButton" name="showFloatingButton" type="checkbox">
+            <span class="slider"></span>
+          </label>
+        </div>
+        <div class="field" id="button-position-row">
+          <label for="buttonPosition">Button position</label>
+          <select id="buttonPosition" name="buttonPosition">
+            <option value="bottom-right">Bottom right</option>
+            <option value="bottom-left">Bottom left</option>
+            <option value="top-right">Top right</option>
+            <option value="top-left">Top left</option>
+          </select>
+        </div>
+        <div class="toggle">
+          <label for="autoHideButton">Auto-hide when idle</label>
+          <label class="switch">
+            <input id="autoHideButton" name="autoHideButton" type="checkbox">
+            <span class="slider"></span>
+          </label>
+        </div>
+        <div class="toggle">
+          <label for="enableContextMenu">Context menu integration</label>
+          <label class="switch">
+            <input id="enableContextMenu" name="enableContextMenu" type="checkbox">
+            <span class="slider"></span>
+          </label>
+        </div>
+      </section>
+
+      <section class="options-card">
+        <h2>Feedback</h2>
+        <div class="toggle">
+          <label for="showNotifications">Show notifications</label>
+          <label class="switch">
+            <input id="showNotifications" name="showNotifications" type="checkbox">
+            <span class="slider"></span>
+          </label>
+        </div>
+        <div class="toggle">
+          <label for="playSound">Play confirmation sound</label>
+          <label class="switch">
+            <input id="playSound" name="playSound" type="checkbox">
+            <span class="slider"></span>
+          </label>
+        </div>
+      </section>
+
+      <section class="options-actions">
+        <div class="status" id="status-message" role="status" aria-live="polite"></div>
+        <div class="buttons">
+          <button type="button" class="btn secondary" id="reset-defaults">Reset defaults</button>
+          <button type="submit" class="btn primary">Save changes</button>
+        </div>
+      </section>
+    </form>
+  </main>
+
+  <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,194 @@
+const DEFAULT_SETTINGS = {
+  folderPath: 'InstantFiles/',
+  namingPattern: 'timestamp',
+  customPattern: 'file_{date}',
+  organizeByType: true,
+  showNotifications: true,
+  playSound: false,
+  autoDetectType: true,
+  enableContextMenu: true,
+  showFloatingButton: true,
+  buttonPosition: 'bottom-right',
+  autoHideButton: true,
+  selectionThreshold: 10,
+  enableSmartDetection: true
+};
+
+const manifest = chrome.runtime.getManifest();
+
+document.addEventListener('DOMContentLoaded', () => {
+  renderVersion();
+  setupForm();
+  loadSettings();
+});
+
+function renderVersion() {
+  const versionEl = document.getElementById('extension-version');
+  if (versionEl) {
+    versionEl.textContent = `v${manifest.version}`;
+  }
+}
+
+function setupForm() {
+  const form = document.getElementById('options-form');
+  const namingPattern = document.getElementById('namingPattern');
+  const customPatternRow = document.getElementById('custom-pattern-row');
+  const selectionSlider = document.getElementById('selectionThreshold');
+  const selectionValue = document.getElementById('selectionThresholdValue');
+  const showFloatingButton = document.getElementById('showFloatingButton');
+  const buttonPositionRow = document.getElementById('button-position-row');
+  const resetButton = document.getElementById('reset-defaults');
+
+  if (namingPattern && customPatternRow) {
+    namingPattern.addEventListener('change', () => {
+      const isCustom = namingPattern.value === 'custom';
+      customPatternRow.classList.toggle('hidden', !isCustom);
+    });
+  }
+
+  if (selectionSlider && selectionValue) {
+    const updateSliderValue = () => {
+      selectionValue.textContent = selectionSlider.value;
+    };
+    selectionSlider.addEventListener('input', updateSliderValue);
+    selectionSlider.addEventListener('change', updateSliderValue);
+  }
+
+  if (showFloatingButton && buttonPositionRow) {
+    const togglePositionVisibility = () => {
+      buttonPositionRow.classList.toggle('hidden', !showFloatingButton.checked);
+    };
+    showFloatingButton.addEventListener('change', togglePositionVisibility);
+  }
+
+  if (resetButton) {
+    resetButton.addEventListener('click', () => {
+      applySettings(DEFAULT_SETTINGS);
+      saveSettings(DEFAULT_SETTINGS, { showStatus: true });
+    });
+  }
+
+  if (form) {
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const settings = readFormSettings(form);
+      saveSettings(settings, { showStatus: true });
+    });
+  }
+}
+
+async function loadSettings() {
+  try {
+    const stored = await chrome.storage.sync.get(null);
+    const settings = { ...DEFAULT_SETTINGS, ...stored };
+    applySettings(settings);
+  } catch (error) {
+    console.error('Failed to load settings', error);
+    showStatusMessage('Unable to load saved settings.', 'error');
+  }
+}
+
+function readFormSettings(form) {
+  const data = new FormData(form);
+  const settings = { ...DEFAULT_SETTINGS };
+
+  settings.folderPath = (data.get('folderPath') || DEFAULT_SETTINGS.folderPath).trim() || DEFAULT_SETTINGS.folderPath;
+  settings.namingPattern = data.get('namingPattern') || DEFAULT_SETTINGS.namingPattern;
+  settings.customPattern = (data.get('customPattern') || DEFAULT_SETTINGS.customPattern).trim() || DEFAULT_SETTINGS.customPattern;
+  settings.organizeByType = form.organizeByType.checked;
+  settings.showNotifications = form.showNotifications.checked;
+  settings.playSound = form.playSound.checked;
+  settings.autoDetectType = form.autoDetectType.checked;
+  settings.enableContextMenu = form.enableContextMenu.checked;
+  settings.showFloatingButton = form.showFloatingButton.checked;
+  settings.buttonPosition = form.buttonPosition.value || DEFAULT_SETTINGS.buttonPosition;
+  settings.autoHideButton = form.autoHideButton.checked;
+  settings.selectionThreshold = Number(form.selectionThreshold.value || DEFAULT_SETTINGS.selectionThreshold);
+  settings.enableSmartDetection = form.enableSmartDetection.checked;
+
+  return settings;
+}
+
+function applySettings(settings) {
+  const merged = { ...DEFAULT_SETTINGS, ...settings };
+  const form = document.getElementById('options-form');
+  if (!form) {
+    return;
+  }
+
+  form.folderPath.value = merged.folderPath;
+  form.namingPattern.value = merged.namingPattern;
+  form.customPattern.value = merged.customPattern;
+  form.organizeByType.checked = merged.organizeByType;
+  form.showNotifications.checked = merged.showNotifications;
+  form.playSound.checked = merged.playSound;
+  form.autoDetectType.checked = merged.autoDetectType;
+  form.enableContextMenu.checked = merged.enableContextMenu;
+  form.showFloatingButton.checked = merged.showFloatingButton;
+  form.buttonPosition.value = merged.buttonPosition;
+  form.autoHideButton.checked = merged.autoHideButton;
+  form.selectionThreshold.value = merged.selectionThreshold;
+  form.enableSmartDetection.checked = merged.enableSmartDetection;
+
+  const customPatternRow = document.getElementById('custom-pattern-row');
+  if (customPatternRow) {
+    customPatternRow.classList.toggle('hidden', merged.namingPattern !== 'custom');
+  }
+
+  const selectionValue = document.getElementById('selectionThresholdValue');
+  if (selectionValue) {
+    selectionValue.textContent = String(merged.selectionThreshold);
+  }
+
+  const buttonPositionRow = document.getElementById('button-position-row');
+  if (buttonPositionRow) {
+    buttonPositionRow.classList.toggle('hidden', !merged.showFloatingButton);
+  }
+}
+
+async function saveSettings(settings, { showStatus } = {}) {
+  try {
+    await chrome.storage.sync.set(settings);
+    await refreshBackgroundSettings();
+    if (showStatus) {
+      showStatusMessage('Preferences saved.', 'success');
+    }
+  } catch (error) {
+    console.error('Failed to save settings', error);
+    showStatusMessage('Could not save preferences. Try again.', 'error');
+  }
+}
+
+async function refreshBackgroundSettings() {
+  try {
+    await chrome.runtime.sendMessage({ action: 'refreshSettings' });
+  } catch (error) {
+    // Service worker might be sleeping; ignore the error as settings are persisted.
+    if (error && error.message) {
+      console.warn('Refresh message failed:', error.message);
+    }
+  }
+}
+
+function showStatusMessage(message, intent = 'info') {
+  const statusEl = document.getElementById('status-message');
+  if (!statusEl) {
+    return;
+  }
+
+  statusEl.textContent = message;
+  statusEl.classList.remove('success', 'error');
+
+  if (intent === 'success') {
+    statusEl.classList.add('success');
+  } else if (intent === 'error') {
+    statusEl.classList.add('error');
+  }
+
+  if (intent === 'success') {
+    setTimeout(() => {
+      statusEl.textContent = '';
+      statusEl.classList.remove('success', 'error');
+    }, 2500);
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated options.html to expose all InstantFile preferences
- implement options.js to load and persist settings while refreshing the service worker
- style the preferences surface with options.css and surface the extension version

## Testing
- Manual: Loaded http://127.0.0.1:8000/options.html via `python3 -m http.server 8000` to verify the settings UI renders

------
https://chatgpt.com/codex/tasks/task_b_690426164da083229fc567344d01e5c6