### PR TITLE
Add popup stats storage fallback

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -100,6 +100,16 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   };
 
+  const loadStatsFromStorage = async () => {
+    try {
+      const result = await chrome.storage.local.get('stats');
+      return result && result.stats ? result.stats : null;
+    } catch (storageError) {
+      console.warn('Stats storage read failed:', storageError);
+      return null;
+    }
+  };
+
   const loadStats = async (quiet = false) => {
     try {
       const response = await chrome.runtime.sendMessage({ action: 'getStats' });
@@ -109,9 +119,14 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     } catch (error) {
       console.error('Stats load failed:', error);
-      renderStats(null);
+      const cachedStats = await loadStatsFromStorage();
+      renderStats(cachedStats);
       if (!quiet) {
-        setStatus('Stats unavailable', 'warn');
+        if (cachedStats) {
+          setStatus('Using cached stats', 'info');
+        } else {
+          setStatus('Stats unavailable', 'warn');
+        }
       }
     }
   };


### PR DESCRIPTION
## Summary
- add a storage-based fallback when the popup cannot reach the service worker for stats
- surface an informational status when cached stats are displayed

## Testing
- not run (extension change)


------
https://chatgpt.com/codex/tasks/task_b_6904346f67688322a8e3dee53d64369c