### PR TITLE
Fix stats loading connection error in popup

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -135,7 +135,16 @@ class InstantFile {
           });
         return true;
       } else if (message.action === 'getStats') {
-        sendResponse({ stats: this.stats });
+        // Ensure stats are loaded from storage before responding
+        this.loadStats()
+          .then(() => {
+            sendResponse({ stats: this.stats });
+          })
+          .catch((error) => {
+            console.error('Stats load error:', error);
+            sendResponse({ stats: this.stats });
+          });
+        return true;
       } else if (message.action === 'getSettings') {
         sendResponse({ settings: this.settings });
       } else if (message.action === 'refreshSettings') {


### PR DESCRIPTION
Resolves issue where "Could not establish connection. Receiving end does not exist" error appears when popup tries to load stats.

Changes:
- Added sendMessageWithTimeout() to handle service worker unavailability gracefully
- Connection errors are now silently handled with storage fallback instead of console errors
- Service worker now reloads stats from storage before responding to ensure data consistency
- Improved error messages for users when service worker is unavailable

This fix ensures the popup remains functional even when the service worker is inactive or restarting, which is expected behavior in Manifest V3 extensions.