### PR TITLE
Add configurable context menu formats and save as

### DIFF
--- a/content.js
+++ b/content.js
@@ -175,6 +175,7 @@ class InstaFileContent {
         <button data-format="txt" title="Text">📄</button>
         <button data-format="md" title="Markdown">📝</button>
         <button data-format="pdf" title="PDF">📕</button>
+        <button data-format="saveas" title="Save As">📁</button>
       </div>
     `;
     
@@ -256,6 +257,10 @@ class InstaFileContent {
           <button data-format="pdf" class="instafile-fab-option" title="PDF">
             <span>📕</span>
             <label>PDF</label>
+          </button>
+          <button data-format="saveas" class="instafile-fab-option" title="Save As">
+            <span>📁</span>
+            <label>Save As</label>
           </button>
           <button data-format="code" class="instafile-fab-option" title="Code">
             <span>👨‍💻</span>
@@ -498,11 +503,12 @@ class InstaFileContent {
   }
 
   async saveWithFormat(format) {
-    if (!this.selectedText && format !== 'smart') {
+    const requiresSelection = format !== 'smart' && format !== 'saveas';
+    if (!this.selectedText && requiresSelection) {
       this.showToast('⚠️ No text selected', 'warning');
       return;
     }
-    
+
     const content = this.selectedText || document.title + '\n' + window.location.href;
     
     try {
@@ -513,7 +519,15 @@ class InstaFileContent {
       });
 
       if (response && response.success) {
-        this.showToast(`✅ Saved as ${format.toUpperCase()}`, 'success');
+        const formatLabel = format === 'smart'
+          ? 'Auto'
+          : format === 'saveas'
+            ? 'Save As'
+            : format.toUpperCase();
+        const toastMessage = format === 'saveas'
+          ? '📁 Choose where to save your file'
+          : `✅ Saved as ${formatLabel}`;
+        this.showToast(toastMessage, 'success');
         this.updateButtonStats();
         this.addSaveAnimation();
       }

--- a/options.css
+++ b/options.css
@@ -147,6 +147,65 @@ body {
   color: var(--muted);
 }
 
+.format-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.format-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.35);
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+@media (prefers-color-scheme: light) {
+  .format-option {
+    background: rgba(248, 250, 252, 0.9);
+  }
+}
+
+.format-option:hover {
+  border-color: rgba(56, 189, 248, 0.7);
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.2);
+  transform: translateY(-1px);
+}
+
+.format-option input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  margin: 0;
+  accent-color: rgba(56, 189, 248, 0.9);
+  flex-shrink: 0;
+  align-self: flex-start;
+  margin-top: 2px;
+}
+
+.format-option .format-icon {
+  font-size: 20px;
+}
+
+.format-option .format-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.format-option .format-copy strong {
+  font-size: 14px;
+}
+
+.format-option .format-copy span {
+  font-size: 12px;
+  color: var(--muted);
+}
+
 .toggle {
   display: flex;
   align-items: center;

--- a/options.html
+++ b/options.html
@@ -109,6 +109,12 @@
       </section>
 
       <section class="options-card">
+        <h2>Context menu formats</h2>
+        <p class="help">Choose which formats appear when you right-click selected text.</p>
+        <div class="format-grid" id="context-menu-formats"></div>
+      </section>
+
+      <section class="options-card">
         <h2>Feedback</h2>
         <div class="toggle">
           <label for="showNotifications">Show notifications</label>


### PR DESCRIPTION
## Summary
- add a new options card with checkboxes so users can pick which formats appear in the right-click context menu
- wire the service worker to honor the selected formats, add a Save As… menu entry, and support the save-as workflow via downloads
- surface the Save As option in the floating quick-save UI with tailored toast feedback

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691d1cb0e9bc8322b0d2f2e5c81b52ff)